### PR TITLE
Use LaunchDaemons in /Library instead of /System/Library

### DIFF
--- a/src/main/java/org/jenkinsci/modules/launchd_slave_installer/SlaveInstallerFactoryImpl.java
+++ b/src/main/java/org/jenkinsci/modules/launchd_slave_installer/SlaveInstallerFactoryImpl.java
@@ -34,7 +34,7 @@ public class SlaveInstallerFactoryImpl extends SlaveInstallerFactory {
 
     private static class Predicate implements Callable<Boolean, RuntimeException> {
         public Boolean call() throws RuntimeException {
-            return new File("/bin/launchctl").exists() || new File("/System/Library/LaunchDaemons").exists();
+            return new File("/bin/launchctl").exists() || new File("/Library/LaunchDaemons").exists();
         }
         private static final long serialVersionUID = 1L;
     }

--- a/src/main/resources/org/jenkinsci/modules/launchd_slave_installer/install.sh
+++ b/src/main/resources/org/jenkinsci/modules/launchd_slave_installer/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -ex
 (
-    JAR=/System/Library/LaunchDaemons/org.jenkins-ci.slave.$3.jar
-    DST=/System/Library/LaunchDaemons/org.jenkins-ci.slave.$3.plist
+    JAR=/Library/LaunchDaemons/org.jenkins-ci.slave.$3.jar
+    DST=/Library/LaunchDaemons/org.jenkins-ci.slave.$3.plist
     cp "$1" $DST
     cp "$2" $JAR
     chmod 644 $DST

--- a/src/main/resources/org/jenkinsci/modules/launchd_slave_installer/jenkins-slave.plist
+++ b/src/main/resources/org/jenkinsci/modules/launchd_slave_installer/jenkins-slave.plist
@@ -13,7 +13,7 @@
       <string>/usr/bin/java</string>
       <string>-Xdock:name=Jenkins slave</string>
       <string>-jar</string>
-      <string>/System/Library/LaunchDaemons/org.jenkins-ci.slave.{instanceId}.jar</string>
+      <string>/Library/LaunchDaemons/org.jenkins-ci.slave.{instanceId}.jar</string>
       {args}
     </array>
 


### PR DESCRIPTION
On OS X, Apple reserves the use of /System/Library for its own use. Therefor, Jenkins should install the slave launcher in /Library/LaunchDaemons instead of /System/Library/LaunchDaemons (a full install of Jenkins already uses the correct Library directory).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/launchd-slave-installer-module/1)

<!-- Reviewable:end -->
